### PR TITLE
Fix screenshare audio

### DIFF
--- a/static/audience/index.css
+++ b/static/audience/index.css
@@ -37,6 +37,11 @@ a.button {
   color: white;
 }
 
+video {
+  max-height: 100%;
+  width: 100%;
+}
+
 main {
   height: 100%;
   display: flex;

--- a/static/audience/index.scss
+++ b/static/audience/index.scss
@@ -15,6 +15,11 @@ a.button {
 	color: white;
 }
 
+video {
+	max-height: 100%;
+	width: 100%;
+}
+
 main {
 	height: 100%;
 	display: flex;

--- a/static/projectionist/index.css
+++ b/static/projectionist/index.css
@@ -27,6 +27,10 @@ html {
   padding: 20px;
 }
 
+body {
+  height: 100%;
+}
+
 svg {
   vertical-align: middle;
 }

--- a/static/projectionist/index.css
+++ b/static/projectionist/index.css
@@ -32,7 +32,7 @@ svg {
 }
 
 main {
-  height: 100%;
+  min-height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -66,6 +66,12 @@ main section#setup button svg {
   height: 2rem;
 }
 
+div.ffvideo {
+  flex: 0 1 auto;
+}
+div.ffvideo video {
+  max-width: 100%;
+}
 div.ffvideo video#fallback-player {
   display: none;
 }
@@ -79,5 +85,9 @@ main[data-state=ready] .stateful.ready {
 }
 
 main[data-state=playing] .stateful.playing {
+  display: initial;
+}
+
+main[data-state=sharing] .stateful.sharing {
   display: initial;
 }

--- a/static/projectionist/index.html
+++ b/static/projectionist/index.html
@@ -10,10 +10,11 @@
                 <label class="button center">
                     <input type="file" id="src" accept="video/*, audio/*"></input>
                     <h1>
-                        <span id="load" class="stateful initial">Load </span><i data-feather="film"></i><span id="movie-name"></span>
+                        <span id="load" class="stateful initial sharing">Load </span><i data-feather="film"></i><span id="movie-name"></span>
                     </h1>
                 </label>
-                <button class="button center" id="share-screen" title="Audio will only work with Chrome and when streaming a chrome tab">Or share you're screen</button>
+                <button class="button center stateful initial" id="share-screen" title="Audio will only work with Chrome and when streaming a chrome tab">Or share you're screen</button>
+                <h1 class="stateful sharing center">Sharing Screen</h1>
                 <button id="play" class="button center stateful ready">
                     <h1>Start the movie <i data-feather="video"></i></h1>
                 </button>

--- a/static/projectionist/index.js
+++ b/static/projectionist/index.js
@@ -7,8 +7,12 @@ const share_screen = document.getElementById("share-screen");
 // the mozCaptureStream() call removes the audio from the video element and stream.
 // Likely this will be fixed if and when mozCaptureStream stops being prefixed
 // For now using a proxi video element for local playback seems to solve this
-const fallback_player = document.getElementById("fallback-player")
-player.captureStream = player.captureStream || player.mozCaptureStream;
+player.captureStream = player.captureStream || function() {
+    const fallback_player = document.getElementById("fallback-player")
+    const stream = player.mozCaptureStream.apply(arguments);
+    fallback_player.srcObject = stream;
+    return stream;
+}.bind(player);
 let remoteStream;
 let controlStream;
 
@@ -33,8 +37,8 @@ share_screen.addEventListener("click", async function(ev) {
             main_element.setAttribute("data-state", "initial");
         });
     }
+    remoteStream = new MediaStream();
     player.srcObject = captureStream;
-    remoteStream = captureStream;
     controlStream = captureStream;
     controlStream.onaddtrack = updateTracks;
     player.load();
@@ -47,7 +51,6 @@ play_button.addEventListener("click", function(ev) {
     remoteStream = new MediaStream();
     controlStream = player.captureStream()
     controlStream.onaddtrack = updateTracks;
-    fallback_player.srcObject = controlStream;
     player.load();
 });
 

--- a/static/projectionist/index.js
+++ b/static/projectionist/index.js
@@ -9,7 +9,9 @@ const share_screen = document.getElementById("share-screen");
 // For now using a proxi video element for local playback seems to solve this
 player.captureStream = player.captureStream || function() {
     const fallback_player = document.getElementById("fallback-player")
-    const stream = player.mozCaptureStream.apply(arguments);
+	console.debug(this);
+	console.debug(player);
+    const stream = this.mozCaptureStream.apply(this, arguments);
     fallback_player.srcObject = stream;
     return stream;
 }.bind(player);

--- a/static/projectionist/index.js
+++ b/static/projectionist/index.js
@@ -42,10 +42,12 @@ share_screen.addEventListener("click", async function(ev) {
         });
     }
     remoteStream = new MediaStream();
-    player.srcObject = captureStream;
+    //player.srcObject = captureStream;
     controlStream = captureStream;
-    controlStream.onaddtrack = updateTracks;
-    player.load();
+    controlStream.onaddtrack = (e) => { updateTracks(e.track); };
+    captureStream.getTracks().forEach(track => { updateTracks(track); });
+    //player.load();
+    main_element.setAttribute("data-state", "sharing");
 });
 
 play_button.addEventListener("click", function(ev) {
@@ -54,7 +56,7 @@ play_button.addEventListener("click", function(ev) {
     player.src = video_source_url;
     remoteStream = new MediaStream();
     controlStream = player.captureStream()
-    controlStream.onaddtrack = updateTracks;
+    controlStream.onaddtrack = (e) => { updateTracks(e.track); };
     player.load();
 });
 
@@ -71,12 +73,12 @@ player.addEventListener("play", function() {
 
 const connections = {};
 
-function updateTracks(e) {
+function updateTracks(track) {
     for (let conn in connections) {
-        connections[conn].addTrack(e.track, remoteStream);
+		console.debug("updating tracks", conn)
+        connections[conn].addTrack(track, remoteStream);
     }
 }
-
 
 async function main() {
     console.debug("loading application");

--- a/static/projectionist/index.js
+++ b/static/projectionist/index.js
@@ -96,13 +96,18 @@ async function main() {
                 }
             }
 
+            // if there is a movie playing
             if (controlStream) {
-                controlStream.getTracks().forEach(track => projectionist.addTrack(track, remoteStream));
+                controlStream.getTracks().forEach(track => {
+                    try {
+                        projectionist.addTrack(track, remoteStream)
+                    } catch (err) {
+                        console.error(msg.from, err);
+                    }
+                });
             }
 
             configure(projectionist, signaler, msg.from);
-
-            return;
         }
         await connections[msg.from].onmessage(msg);
     };

--- a/static/projectionist/index.js
+++ b/static/projectionist/index.js
@@ -19,7 +19,11 @@ let controlStream;
 share_screen.addEventListener("click", async function(ev) {
     const gdmOptions = {
         video: true,
-        audio: true
+        audio: {
+            echoCancellation: false,
+            noiseSuppression: false,
+            sampleRate: 44100
+        }
     };
     let captureStream = null;
 

--- a/static/projectionist/index.js
+++ b/static/projectionist/index.js
@@ -34,10 +34,9 @@ share_screen.addEventListener("click", async function(ev) {
         });
     }
     player.srcObject = captureStream;
-    remoteStream = new MediaStream();
-    controlStream = player.captureStream()
+    remoteStream = captureStream;
+    controlStream = captureStream;
     controlStream.onaddtrack = updateTracks;
-    fallback_player.srcObject = controlStream;
     player.load();
 });
 

--- a/static/projectionist/index.scss
+++ b/static/projectionist/index.scss
@@ -1,5 +1,9 @@
 @use "../shared/_shared.scss";
 
+body {
+	height: 100%;
+}
+
 // States
 .initial { }
 .ready { }

--- a/static/projectionist/index.scss
+++ b/static/projectionist/index.scss
@@ -10,7 +10,7 @@ svg {
 }
 
 main {
-	height: 100%;
+	min-height: 100%;
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -47,6 +47,10 @@ main {
 }
 
 div.ffvideo {
+	flex: 0 1 auto;
+	video {
+		max-width: 100%;
+	}
 	video#fallback-player {
 		display: none;
 	}
@@ -66,6 +70,12 @@ main[data-state=ready] {
 
 main[data-state=playing] {
 	.stateful.playing {
+		display: initial;
+	}
+}
+
+main[data-state=sharing] {
+	.stateful.sharing {
 		display: initial;
 	}
 }


### PR DESCRIPTION
When sharing a chrome tab the audio was faded and tinny. It appears this was because the stream was getting passed around too much.